### PR TITLE
Fix update of params in ProjectParamsWizardPage.

### DIFF
--- a/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewAngular2ProjectParamsWizardPage.java
+++ b/ts.eclipse.ide.angular2.cli/src/ts/eclipse/ide/angular2/internal/cli/wizards/NewAngular2ProjectParamsWizardPage.java
@@ -299,6 +299,8 @@ public class NewAngular2ProjectParamsWizardPage extends AbstractWizardPage {
 	public void handleEvent(Event event) {
 		super.handleEvent(event);
 		Widget item = event != null ? event.item : null;
+		if (event != null && item == null)
+			item = event.widget;
 		if (item == chkSkipInstall)
 			skipInstall = chkSkipInstall.getSelection();
 		else if (item == chkSkipGit)


### PR DESCRIPTION
Fix angelozerr/angular-eclipse#98

In the EventHandler I used `event.item` which seems to be null in this case.  
Now it is using `event.widget`, if `event.item` is null.  
Seems to work fine under Eclipse Oxygen.  
Perhaps we should take a look at other WizardPages too, because we are always using `event.item`.