### PR TITLE
Fix bug in AngularCLI Global preferences and CLI setting in Angular Project-Wizard

### DIFF
--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIProjectSettings.java
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/AngularCLIProjectSettings.java
@@ -7,6 +7,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChange
 
 import ts.eclipse.ide.angular.cli.AngularCLIPlugin;
 import ts.eclipse.ide.angular.cli.preferences.AngularCLIPreferenceConstants;
+import ts.eclipse.ide.angular.cli.utils.CLIProcessHelper;
 import ts.eclipse.ide.core.resources.AbstractTypeScriptSettings;
 import ts.utils.StringUtils;
 
@@ -21,12 +22,35 @@ public class AngularCLIProjectSettings extends AbstractTypeScriptSettings {
 
 	}
 
-	public File getNgFile() {
+	/** Use the global CLI-Installation? */
+	public boolean useGlobalCLIInstallation() {
+		return super.getBooleanPreferencesValue(AngularCLIPreferenceConstants.NG_USE_GLOBAL_INSTALLATION, false);
+	}
+
+	/** Returns the directory, which contains the custom ng-file. */
+	public File getCustomNgLocation() {
 		String path = super.getStringPreferencesValue(AngularCLIPreferenceConstants.NG_CUSTOM_FILE_PATH, null);
 		if (!StringUtils.isEmpty(path)) {
 			return resolvePath(path);
 		}
 		return null;
+	}
+
+	/** Returns the custom ng-file. */
+	public File getCustomNgFile() {
+		File ngFile = getCustomNgLocation();
+		if (ngFile != null && ngFile.isDirectory())
+			return new File(ngFile, CLIProcessHelper.getNgFileName());
+		else
+			return null;
+	}
+
+	/** Returns the ng-file ("ng"/"ng.cmd"). */
+	public File getNgFile() {
+		if (useGlobalCLIInstallation())
+			return CLIProcessHelper.findNg();
+		else
+			return getCustomNgFile();
 	}
 
 	public boolean isExecuteNgWithFile() {

--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/launch/AngularCLILaunchHelper.java
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/launch/AngularCLILaunchHelper.java
@@ -94,7 +94,7 @@ public class AngularCLILaunchHelper {
 	public static void updateNgFilePath(IProject project, ILaunchConfigurationWorkingCopy newConfiguration)
 			throws CoreException {
 		AngularCLIProjectSettings  settings = AngularCLIProject.getAngularCLIProject(project).getSettings();
-		File ngFile = settings.getNgFile();
+		File ngFile = settings.getCustomNgLocation();
 		if (ngFile != null) {
 			newConfiguration.setAttribute(AngularCLILaunchConstants.NG_FILE_PATH, FileUtils.getPath(ngFile));
 			newConfiguration.setAttribute(AngularCLILaunchConstants.EXECUTE_NG_WITH_FILE, settings.isExecuteNgWithFile());

--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/preferences/AngularCLIConfigurationBlock.java
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/preferences/AngularCLIConfigurationBlock.java
@@ -280,37 +280,43 @@ public class AngularCLIConfigurationBlock extends OptionsConfigurationBlock {
 		if (useGlobal) {
 			ngFile = CLIProcessHelper.findNg();
 			if (ngFile == null) {
-				// ERROR: ng was not installed with "npm install @angular/cli
-				// -g"
+				// ERROR: ng was not installed with "npm install -g @angular/cli"
 				return new CLIStatus(null, AngularCLIMessages.AngularCLIConfigurationBlock_ngGlobal_notFound_error);
 			}
-		} else if (!globalPrefs) {
+		} else {
 			String ngPath = ngCustomFilePath.getText();
 			if (StringUtils.isEmpty(ngPath)) {
-				// ERROR: the installed path is empty
-				return new CLIStatus(null, AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_required_error);
+				if (!globalPrefs) {
+					// ERROR: the installed path is empty
+					return new CLIStatus(null, AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_required_error);
+				}
+				else
+					return StatusInfo.OK_STATUS;
 			} else {
 				ngFile = WorkbenchResourceUtil.resolvePath(ngPath, getProject());
-				if (!ngFile.isDirectory()) {
-					// ERROR: the ng path must be a directory which contains the
-					// ng/ng.cmd
-					return new CLIStatus(null,
-							NLS.bind(AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_notDir_error,
-									FileUtils.getPath(ngFile)));
+				if (ngFile == null || !ngFile.isDirectory()) {
+					if (!globalPrefs) {
+						// ERROR: the ng path must be a directory which contains the
+						// ng/ng.cmd
+						return new CLIStatus(null,
+								NLS.bind(AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_notDir_error,
+										FileUtils.getPath(ngFile)));
+					}
+					else
+						return StatusInfo.OK_STATUS;
 				}
 				ngFile = new File(ngFile, CLIProcessHelper.getNgFileName());
 			}
 		}
-		if (!globalPrefs) {
-			if (!ngFile.exists()) {
+		if (!ngFile.exists()) {
+			if (!globalPrefs) {
 				// ERROR: ng file doesn't exists
 				return new CLIStatus(null,
 						NLS.bind(AngularCLIMessages.AngularCLIConfigurationBlock_ngCustomFile_exists_error,
 								FileUtils.getPath(ngFile)));
 			}
-		}
-		else {
-			return StatusInfo.OK_STATUS;
+			else
+				return StatusInfo.OK_STATUS;
 		}
 		// ng path is valid
 		return new CLIStatus(ngFile, null);

--- a/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/wizards/WizardNewNgProjectCreationPage.java
+++ b/ts.eclipse.ide.angular.cli/src/ts/eclipse/ide/angular/internal/cli/wizards/WizardNewNgProjectCreationPage.java
@@ -39,7 +39,6 @@ import org.osgi.service.prefs.BackingStoreException;
 
 import ts.eclipse.ide.angular.cli.AngularCLIPlugin;
 import ts.eclipse.ide.angular.cli.preferences.AngularCLIPreferenceConstants;
-import ts.eclipse.ide.angular.cli.utils.CLIProcessHelper;
 import ts.eclipse.ide.angular.cli.utils.CLIStatus;
 import ts.eclipse.ide.angular.cli.utils.NgVersionJob;
 import ts.eclipse.ide.angular.internal.cli.AngularCLIMessages;
@@ -149,10 +148,6 @@ public class WizardNewNgProjectCreationPage extends AbstractWizardNewTypeScriptP
 			try {
 				AngularCLIProjectSettings settings = AngularCLIProject.getAngularCLIProject(getProjectHandle()).getSettings();
 				ngFile = settings.getNgFile();
-				if (ngFile != null && ngFile.isDirectory())
-					ngFile = new File(ngFile, CLIProcessHelper.getNgFileName());
-				else
-					ngFile = null;
 			} catch (CoreException e) {
 				Trace.trace(Trace.SEVERE, "Error while getting Project settings", e);
 				ngFile = null;


### PR DESCRIPTION
In the global preferences page, the ng version wasn't shown anymore.  
Also the Angular-Project wizard accidentally used the method "getNgFile" from AngularCLIProjectSettings, which returns the custom ng folder only.
I renamed the method to "getCustomNgLocation", since it returns the folder you selected as a custom ng directory, and created a method getNgFile, which returns the "ng.cmd"-file (global or custom).